### PR TITLE
✨ Feat: add ability to use example files

### DIFF
--- a/src/gladvent.gleam
+++ b/src/gladvent.gleam
@@ -24,6 +24,7 @@ pub fn main() {
     |> glint.add(at: ["new"], do: new.new_command())
     |> glint.group_flag(at: ["run"], of: run.timeout_flag())
     |> glint.group_flag(at: ["run"], of: run.allow_crash_flag())
+    |> glint.group_flag(at: ["run"], of: run.use_example_flag())
     |> glint.add(at: ["run"], do: run.run_command())
     |> glint.add(at: ["run", "all"], do: run.run_all_command())
 

--- a/src/gladvent.gleam
+++ b/src/gladvent.gleam
@@ -24,7 +24,6 @@ pub fn main() {
     |> glint.add(at: ["new"], do: new.new_command())
     |> glint.group_flag(at: ["run"], of: run.timeout_flag())
     |> glint.group_flag(at: ["run"], of: run.allow_crash_flag())
-    |> glint.group_flag(at: ["run"], of: run.example_flag())
     |> glint.add(at: ["run"], do: run.run_command())
     |> glint.add(at: ["run", "all"], do: run.run_all_command())
 

--- a/src/gladvent.gleam
+++ b/src/gladvent.gleam
@@ -24,7 +24,7 @@ pub fn main() {
     |> glint.add(at: ["new"], do: new.new_command())
     |> glint.group_flag(at: ["run"], of: run.timeout_flag())
     |> glint.group_flag(at: ["run"], of: run.allow_crash_flag())
-    |> glint.group_flag(at: ["run"], of: run.use_example_flag())
+    |> glint.group_flag(at: ["run"], of: run.example_flag())
     |> glint.add(at: ["run"], do: run.run_command())
     |> glint.add(at: ["run", "all"], do: run.run_all_command())
 

--- a/src/gladvent/internal/cmd.gleam
+++ b/src/gladvent/internal/cmd.gleam
@@ -23,14 +23,6 @@ fn find_root(path: String) -> String {
   }
 }
 
-pub fn input_root() {
-  filepath.join(root(), "input")
-}
-
-pub fn input_dir(year) {
-  filepath.join(input_root(), int.to_string(year))
-}
-
 pub fn src_root() {
   filepath.join(root(), "src")
 }

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -40,13 +40,13 @@ fn create_src_file(ctx: Context) {
 }
 
 fn create_input_root(_ctx: Context) {
-  cmd.input_root()
+  input.root()
   |> create_dir
 }
 
 fn create_input_dir(ctx: Context) {
   ctx.year
-  |> cmd.input_dir
+  |> input.dir
   |> create_dir
 }
 

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -7,7 +7,6 @@ import gladvent/internal/input
 import gladvent/internal/parse.{type Day}
 import gladvent/internal/util
 import gleam/int
-import gleam/iterator
 import gleam/list
 import gleam/pair
 import gleam/result
@@ -115,13 +114,18 @@ fn handle_file_open_failure(
 }
 
 fn do(ctx: Context) -> String {
-  let seq =
-    iterator.from_list([create_input_root, create_input_dir, create_input_file])
-    |> append(case ctx.create_example_file {
+  let seq = [
+    create_input_root,
+    create_input_dir,
+    create_input_file,
+    create_input_example_file,
+    create_src_dir,
+    create_src_file,
+    ..case ctx.create_example_file {
       True -> [create_input_example_file]
       False -> []
-    })
-    |> append([create_src_dir, create_src_file])
+    }
+  ]
 
   let successes = fn(good) {
     case good {
@@ -141,7 +145,7 @@ fn do(ctx: Context) -> String {
 
   let #(good, bad) =
     {
-      use acc, f <- iterator.fold(seq, #("", ""))
+      use acc, f <- list.fold(seq, #("", ""))
       case f(ctx) {
         Ok("") -> acc
         Ok(o) -> pair.map_first(acc, newline_tab(_, o))
@@ -228,8 +232,4 @@ fn do_exclusive(
     let assert Ok(Nil) = file_stream.close(file)
   })
   f(file)
-}
-
-fn append(to: iterator.Iterator(a), list: List(a)) {
-  iterator.append(to, iterator.from_list(list))
 }

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -214,7 +214,7 @@ pub fn example_flag() {
   glint.bool_flag("example")
   |> glint.flag_default(False)
   |> glint.flag_help(
-    "Generate example input files to run your solution against the task description's input",
+    "Generate example input files to run your solution against",
   )
 }
 

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -118,7 +118,6 @@ fn do(ctx: Context) -> String {
     create_input_root,
     create_input_dir,
     create_input_file,
-    create_input_example_file,
     create_src_dir,
     create_src_file,
     ..case ctx.create_example_file {

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -3,6 +3,7 @@ import file_streams/file_stream
 import file_streams/file_stream_error
 import filepath
 import gladvent/internal/cmd
+import gladvent/internal/input
 import gladvent/internal/parse.{type Day}
 import gladvent/internal/util
 import gleam/int
@@ -50,7 +51,15 @@ fn create_input_dir(ctx: Context) {
 }
 
 fn create_input_file(ctx: Context) {
-  let input_path = input_path(ctx.year, ctx.day)
+  let input_path = input.get_file_path(ctx.year, ctx.day, input.Puzzle)
+
+  do_exclusive(input_path, fn(_) { Nil })
+  |> result.map_error(handle_file_open_failure(_, input_path))
+  |> result.replace(input_path)
+}
+
+fn create_input_example_file(ctx: Context) {
+  let input_path = input.get_file_path(ctx.year, ctx.day, input.Example)
 
   do_exclusive(input_path, fn(_) { Nil })
   |> result.map_error(handle_file_open_failure(_, input_path))
@@ -69,10 +78,6 @@ fn err_to_string(e: Err) -> String {
     FailedToCreateFile(f) -> "failed to create file: " <> f
     FileAlreadyExists(f) -> "file already exists: " <> f
   }
-}
-
-fn input_path(year: Int, day: Day) -> String {
-  filepath.join(cmd.input_dir(year), int.to_string(day) <> ".txt")
 }
 
 fn gleam_src_path(year: Int, day: Day) -> String {
@@ -113,6 +118,7 @@ fn do(ctx: Context) -> String {
     create_input_root,
     create_input_dir,
     create_input_file,
+    create_input_example_file,
     create_src_dir,
     create_src_file,
   ]

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -191,30 +191,29 @@ fn collect(year: Int, x: #(Day, String)) -> String {
 pub fn new_command() {
   use <- glint.command_help("Create .gleam and input files")
   use <- glint.unnamed_args(glint.MinArgs(1))
-  use parse <- glint.flag(
+  use parse_flag <- glint.flag(
     glint.bool_flag("parse")
     |> glint.flag_default(False)
     |> glint.flag_help("Generate day runners with a parse function"),
   )
+  use example_flag <- glint.flag(
+    glint.bool_flag("example")
+    |> glint.flag_default(False)
+    |> glint.flag_help(
+      "Generate example input files to run your solution against",
+    ),
+  )
   use _, args, flags <- glint.command()
   use days <- result.map(parse.days(args))
   let assert Ok(year) = glint.get_flag(flags, cmd.year_flag())
-  let assert Ok(parse) = parse(flags)
-  let assert Ok(create_example) = glint.get_flag(flags, example_flag())
+  let assert Ok(parse) = parse_flag(flags)
+  let assert Ok(create_example) = example_flag(flags)
 
   cmd.exec(
     days,
     cmd.Endless,
     fn(day) { do(Context(year, day, parse, create_example)) },
     collect_async(year, _),
-  )
-}
-
-pub fn example_flag() {
-  glint.bool_flag("example")
-  |> glint.flag_default(False)
-  |> glint.flag_help(
-    "Generate example input files to run your solution against",
   )
 }
 

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -1,6 +1,6 @@
 import decode
-import filepath
 import gladvent/internal/cmd.{Ending, Endless}
+import gladvent/internal/input
 import gladvent/internal/parse.{type Day}
 import gladvent/internal/runners
 import gladvent/internal/util
@@ -73,14 +73,14 @@ fn do(
   day: Day,
   package: package_interface.Package,
   allow_crash: Bool,
+  input_kind: input.Kind,
 ) -> RunResult {
   use #(pt_1, pt_2, parse) <- result.try(
     runners.get_day(package, year, day)
     |> result.map_error(FailedToGetRunner),
   )
 
-  let input_path =
-    filepath.join(cmd.input_dir(year), int.to_string(day) <> ".txt")
+  let input_path = input.get_file_path(year, day, input_kind)
 
   use input <- result.try(
     input_path
@@ -268,6 +268,12 @@ pub fn allow_crash_flag() {
   |> glint.flag_help("Don't catch exceptions thrown by runners")
 }
 
+pub fn use_example_flag() {
+  glint.bool_flag("use-example")
+  |> glint.flag_default(False)
+  |> glint.flag_help("Use the example as input instead of your puzzle input")
+}
+
 pub fn run_command() -> glint.Command(Result(List(String))) {
   use <- glint.command_help("Run the specified days")
   use <- glint.unnamed_args(glint.MinArgs(1))
@@ -275,6 +281,11 @@ pub fn run_command() -> glint.Command(Result(List(String))) {
   use days <- result.then(parse.days(args))
   let assert Ok(year) = glint.get_flag(flags, cmd.year_flag())
   let assert Ok(allow_crash) = glint.get_flag(flags, allow_crash_flag())
+  let assert Ok(use_example) = case glint.get_flag(flags, use_example_flag()) {
+    Ok(True) -> Ok(input.Puzzle)
+    Ok(False) -> Ok(input.Example)
+    Error(a) -> Error(a)
+  }
 
   let spinner =
     spinner.new(
@@ -298,7 +309,11 @@ pub fn run_command() -> glint.Command(Result(List(String))) {
   )
 
   days
-  |> cmd.exec(timing, do(year, _, package, allow_crash), collect_async(year, _))
+  |> cmd.exec(
+    timing,
+    do(year, _, package, allow_crash, use_example),
+    collect_async(year, _),
+  )
 }
 
 pub fn run_all_command() -> glint.Command(Result(List(String))) {
@@ -337,5 +352,9 @@ pub fn run_all_command() -> glint.Command(Result(List(String))) {
     |> result.replace_error(Nil)
   })
   |> list.sort(int.compare)
-  |> cmd.exec(timing, do(year, _, package, allow_crash), collect_async(year, _))
+  |> cmd.exec(
+    timing,
+    do(year, _, package, allow_crash, input.Puzzle),
+    collect_async(year, _),
+  )
 }

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -268,20 +268,21 @@ pub fn allow_crash_flag() {
   |> glint.flag_help("Don't catch exceptions thrown by runners")
 }
 
-pub fn example_flag() {
-  glint.bool_flag("example")
-  |> glint.flag_default(False)
-  |> glint.flag_help("Use the example as input instead of your puzzle input")
-}
-
 pub fn run_command() -> glint.Command(Result(List(String))) {
   use <- glint.command_help("Run the specified days")
   use <- glint.unnamed_args(glint.MinArgs(1))
+  use example_flag <- glint.flag(
+    glint.bool_flag("example")
+    |> glint.flag_default(False)
+    |> glint.flag_help(
+      "Generate example input files to run your solution against",
+    ),
+  )
   use _, args, flags <- glint.command()
   use days <- result.then(parse.days(args))
   let assert Ok(year) = glint.get_flag(flags, cmd.year_flag())
   let assert Ok(allow_crash) = glint.get_flag(flags, allow_crash_flag())
-  let assert Ok(use_example) = case glint.get_flag(flags, example_flag()) {
+  let assert Ok(use_example) = case example_flag(flags) {
     Error(a) -> Error(a)
     Ok(True) -> Ok(input.Example)
     _ -> Ok(input.Puzzle)

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -281,7 +281,7 @@ pub fn run_command() -> glint.Command(Result(List(String))) {
   use days <- result.then(parse.days(args))
   let assert Ok(year) = glint.get_flag(flags, cmd.year_flag())
   let assert Ok(allow_crash) = glint.get_flag(flags, allow_crash_flag())
-  let assert Ok(use_example) = case glint.get_flag(flags, use_example_flag()) {
+  let assert Ok(use_example) = case glint.get_flag(flags, example_flag()) {
     Error(a) -> Error(a)
     Ok(True) -> Ok(input.Example)
     _ -> Ok(input.Puzzle)

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -282,9 +282,9 @@ pub fn run_command() -> glint.Command(Result(List(String))) {
   let assert Ok(year) = glint.get_flag(flags, cmd.year_flag())
   let assert Ok(allow_crash) = glint.get_flag(flags, allow_crash_flag())
   let assert Ok(use_example) = case glint.get_flag(flags, use_example_flag()) {
-    Ok(True) -> Ok(input.Puzzle)
-    Ok(False) -> Ok(input.Example)
     Error(a) -> Error(a)
+    Ok(True) -> Ok(input.Example)
+    _ -> Ok(input.Puzzle)
   }
 
   let spinner =

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -268,8 +268,8 @@ pub fn allow_crash_flag() {
   |> glint.flag_help("Don't catch exceptions thrown by runners")
 }
 
-pub fn use_example_flag() {
-  glint.bool_flag("use-example")
+pub fn example_flag() {
+  glint.bool_flag("example")
   |> glint.flag_default(False)
   |> glint.flag_help("Use the example as input instead of your puzzle input")
 }

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -275,7 +275,7 @@ pub fn run_command() -> glint.Command(Result(List(String))) {
     glint.bool_flag("example")
     |> glint.flag_default(False)
     |> glint.flag_help(
-      "Generate example input files to run your solution against",
+      "Run solutions against example inputs (found at input/<year>/<day>.example.txt)",
     ),
   )
   use _, args, flags <- glint.command()

--- a/src/gladvent/internal/input.gleam
+++ b/src/gladvent/internal/input.gleam
@@ -8,9 +8,17 @@ pub type Kind {
 }
 
 pub fn get_file_path(year: Int, day: Int, input_kind: Kind) -> String {
-  filepath.join(cmd.input_dir(year), int.to_string(day))
+  filepath.join(dir(year), int.to_string(day))
   <> case input_kind {
     Example -> ".example.txt"
     Puzzle -> ".txt"
   }
+}
+
+pub fn root() {
+  filepath.join(cmd.root(), "input")
+}
+
+pub fn dir(year) {
+  filepath.join(root(), int.to_string(year))
 }

--- a/src/gladvent/internal/input.gleam
+++ b/src/gladvent/internal/input.gleam
@@ -1,0 +1,16 @@
+import filepath
+import gladvent/internal/cmd
+import gleam/int
+
+pub type Kind {
+  Example
+  Puzzle
+}
+
+pub fn get_file_path(year: Int, day: Int, input_kind: Kind) -> String {
+  filepath.join(cmd.input_dir(year), int.to_string(day))
+  <> case input_kind {
+    Example -> ".example.txt"
+    Puzzle -> ".txt"
+  }
+}


### PR DESCRIPTION
My puzzle workflow is usually the following:

1. understand the task
2. write a solution
3. run the solution with the example input in the task
4. debug the solution
5. run the solution for my puzzle input
6. write solution for the 2nd part
7. repeat 3-5.

With `gladvent`, steps 5 and 7 always involve deleting my puzzle input from the input file, then copying it back.

With this PR:
- the `new` command creates a `{day}.example.txt` file as well
- I introduced a new bool flag for the `run` command, `--use-example`. If it is present, the runner will pass the example txt as input

If I missed anything, please reach out and I'll gladly update my PR.