### PR TITLE
Add the possibility to fetch the input directly from the AoC website

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -22,6 +22,8 @@ filepath = ">= 1.0.0 and < 2.0.0"
 tom = ">= 1.0.0 and < 2.0.0"
 decode = ">= 0.2.0 and < 1.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"
+gleam_httpc = ">= 4.0.0 and < 5.0.0"
+gleam_http = ">= 3.7.1 and < 4.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -24,6 +24,7 @@ decode = ">= 0.2.0 and < 1.0.0"
 gleam_json = ">= 1.0.0 and < 3.0.0"
 gleam_httpc = ">= 4.0.0 and < 5.0.0"
 gleam_http = ">= 3.7.1 and < 4.0.0"
+envoy = ">= 1.0.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.2.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -8,6 +8,8 @@ packages = [
   { name = "gleam_community_ansi", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "4CD513FC62523053E62ED7BAC2F36136EC17D6A8942728250A9A00A15E340E4B" },
   { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
   { name = "gleam_erlang", version = "0.30.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "760618870AE4A497B10C73548E6E44F43B76292A54F0207B3771CBB599C675B4" },
+  { name = "gleam_http", version = "3.7.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_http", source = "hex", outer_checksum = "A9EE0722106FCCAB8AD3BF9D0A3EFF92BFE8561D59B83BAE96EB0BE1938D4E0F" },
+  { name = "gleam_httpc", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_http", "gleam_stdlib"], otp_app = "gleam_httpc", source = "hex", outer_checksum = "76FEEC99473E568EBA34336A37CF3D54629ACE77712950DC9BB097B5FD664664" },
   { name = "gleam_json", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "0A57FB5666E695FD2BEE74C0428A98B0FC11A395D2C7B4CDF5E22C5DD32C74C6" },
   { name = "gleam_otp", version = "0.14.1", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "5A8CE8DBD01C29403390A7BD5C0A63D26F865C83173CF9708E6E827E53159C65" },
   { name = "gleam_package_interface", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_package_interface", source = "hex", outer_checksum = "CF3BFC5D0997750D9550D8D73A90F4B8D71C6C081B20ED4E70FFBE1E99AFC3C2" },
@@ -29,6 +31,8 @@ argv = { version = "~> 1.0" }
 decode = { version = ">= 0.2.0 and < 1.0.0" }
 filepath = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_erlang = { version = "~> 0.7 or ~> 1.0" }
+gleam_http = { version = ">= 3.7.1 and < 4.0.0" }
+gleam_httpc = { version = ">= 4.0.0 and < 5.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 3.0.0" }
 gleam_otp = { version = "~> 0.4 or ~> 1.0" }
 gleam_package_interface = { version = "~> 1.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,6 +4,7 @@
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "decode", version = "0.5.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "decode", source = "hex", outer_checksum = "05E14DC95A550BA51B8774485B04894B87A898C588B9B1C920104B110AED218B" },
+  { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
   { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
   { name = "gleam_community_ansi", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "4CD513FC62523053E62ED7BAC2F36136EC17D6A8942728250A9A00A15E340E4B" },
   { name = "gleam_community_colour", version = "1.4.1", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "386CB9B01B33371538672EEA8A6375A0A0ADEF41F17C86DDCB81C92AD00DA610" },
@@ -29,6 +30,7 @@ packages = [
 [requirements]
 argv = { version = "~> 1.0" }
 decode = { version = ">= 0.2.0 and < 1.0.0" }
+envoy = { version = ">= 1.0.2 and < 2.0.0" }
 filepath = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_erlang = { version = "~> 0.7 or ~> 1.0" }
 gleam_http = { version = ">= 3.7.1 and < 4.0.0" }

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -46,13 +46,13 @@ fn create_input_file(
 ) -> fn() -> Result(String, Err) {
   fn() {
     let input_path = input.get_file_path(ctx.year, ctx.day, kind)
-    case kind, ctx.fetch_input {
-      input.Puzzle, True -> {
+    case kind {
+      input.Puzzle if ctx.fetch_input -> {
         use content <- result.try(download_input(ctx))
         simplifile.write(input_path, content)
         |> result.map_error(FailedToWriteToFile(_))
       }
-      _, _ -> {
+      _ -> {
         simplifile.create_file(input_path)
         |> result.map_error(handle_file_open_failure(_, input_path))
       }

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -4,6 +4,7 @@ import gladvent/internal/cmd
 import gladvent/internal/input
 import gladvent/internal/parse.{type Day}
 import gladvent/internal/util
+import gleam/http
 import gleam/http/request
 import gleam/http/response
 import gleam/httpc
@@ -140,16 +141,19 @@ fn get_cookie_value() -> Result(String, Err) {
 
 fn download_input(ctx: Context) -> Result(String, Err) {
   use cookie <- result.try(get_cookie_value())
-  let url =
-    "https://adventofcode.com/"
-    <> int.to_string(ctx.year)
-    <> "/day/"
-    <> int.to_string(ctx.day)
-    <> "/input"
-  let assert Ok(base_req) = request.to(url)
-  let req = request.prepend_header(base_req, "Cookie", "session=" <> cookie)
   use resp <- result.try(
-    httpc.send(req)
+    request.new()
+    |> request.set_host("adventofcode.com")
+    |> request.set_path(
+      "/"
+      <> int.to_string(ctx.year)
+      <> "/day/"
+      <> int.to_string(ctx.day)
+      <> "/input",
+    )
+    |> request.set_scheme(http.Https)
+    |> request.set_cookie("session", cookie)
+    |> httpc.send()
     |> result.map_error(HttpError(_)),
   )
   case resp.status {

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -56,9 +56,17 @@ fn create_input_file(
     let input_path = input.get_file_path(ctx.year, ctx.day, kind)
     case kind {
       input.Puzzle if ctx.fetch_input -> {
-        use content <- result.try(download_input(ctx))
-        simplifile.write(input_path, content)
-        |> result.map_error(FailedToWriteToFile(_))
+        case
+          simplifile.is_file(input_path),
+          simplifile.is_directory(input_path)
+        {
+          Ok(False), Ok(False) -> {
+            use content <- result.try(download_input(ctx))
+            simplifile.write(input_path, content)
+            |> result.map_error(FailedToWriteToFile(_))
+          }
+          _, _ -> Error(FileAlreadyExists(input_path))
+        }
       }
       _ -> {
         simplifile.create_file(input_path)

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -93,7 +93,8 @@ fn err_to_string(e: Err) -> String {
       "'" <> aoc_cookie_name <> "' environment variable not defined"
     FailedToCreateDir(d) -> "failed to create dir: " <> d
     FailedToCreateFile(f) -> "failed to create file: " <> f
-    FailedToWriteToFile(e) -> "failed to write to file:" <> string.inspect(e)
+    FailedToWriteToFile(e) ->
+      "failed to write to file:" <> simplifile.describe_error(e)
     FileAlreadyExists(f) -> "file already exists: " <> f
     HttpError(e) ->
       "HTTP error while fetching input file: " <> string.inspect(e)

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -1,3 +1,4 @@
+import envoy
 import filepath
 import gladvent/internal/cmd
 import gladvent/internal/input
@@ -12,12 +13,17 @@ import gleam/result
 import gleam/string
 import glint
 import simplifile
-import envoy
 
 const aoc_cookie_name = "AOC_COOKIE"
 
 type Context {
-  Context(year: Int, day: Day, add_parse: Bool, create_example_file: Bool, fetch_input: Bool)
+  Context(
+    year: Int,
+    day: Day,
+    add_parse: Bool,
+    create_example_file: Bool,
+    fetch_input: Bool,
+  )
 }
 
 fn create_src_file(ctx: Context) -> fn() -> Result(String, Err) {
@@ -72,12 +78,14 @@ type Err {
 
 fn err_to_string(e: Err) -> String {
   case e {
-    CookieNotDefined -> "'" <> aoc_cookie_name <> "' environment variable not defined"
+    CookieNotDefined ->
+      "'" <> aoc_cookie_name <> "' environment variable not defined"
     FailedToCreateDir(d) -> "failed to create dir: " <> d
     FailedToCreateFile(f) -> "failed to create file: " <> f
     FailedToWriteToFile(e) -> "failed to write to file:" <> string.inspect(e)
     FileAlreadyExists(f) -> "file already exists: " <> f
-    HttpError(e) -> "HTTP error while fetching input file: " <> string.inspect(e)
+    HttpError(e) ->
+      "HTTP error while fetching input file: " <> string.inspect(e)
   }
 }
 
@@ -125,12 +133,17 @@ fn get_cookie_value() -> Result(String, Err) {
 
 fn download_input(ctx: Context) -> Result(String, Err) {
   use cookie <- result.try(get_cookie_value())
-  let url = "https://adventofcode.com/"<> int.to_string(ctx.year) <>"/day/" <> int.to_string(ctx.day) <> "/input"
+  let url =
+    "https://adventofcode.com/"
+    <> int.to_string(ctx.year)
+    <> "/day/"
+    <> int.to_string(ctx.day)
+    <> "/input"
   let assert Ok(base_req) = request.to(url)
-  let req = request.prepend_header(base_req, "Cookie", "session="<>cookie)
+  let req = request.prepend_header(base_req, "Cookie", "session=" <> cookie)
   use resp <- result.try(
     httpc.send(req)
-    |> result.map_error(HttpError(_))
+    |> result.map_error(HttpError(_)),
   )
   Ok(resp.body)
 }
@@ -245,7 +258,9 @@ pub fn new_command() {
   cmd.exec(
     days,
     cmd.Endless,
-    fn(day) { do(Context(year:, day:, add_parse:, create_example_file:, fetch_input:)) },
+    fn(day) {
+      do(Context(year:, day:, add_parse:, create_example_file:, fetch_input:))
+    },
     collect_async(year, _),
   )
 }

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -153,6 +153,7 @@ fn download_input(ctx: Context) -> Result(String, Err) {
     )
     |> request.set_scheme(http.Https)
     |> request.set_cookie("session", cookie)
+    |> request.set_header("user-agent", "github.com/TanklesXL/gladvent")
     |> httpc.send()
     |> result.map_error(HttpError(_)),
   )

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -3,7 +3,6 @@ import gladvent/internal/cmd
 import gladvent/internal/input
 import gladvent/internal/parse.{type Day}
 import gladvent/internal/util
-import gleam/erlang/os
 import gleam/http/request
 import gleam/httpc
 import gleam/int
@@ -13,6 +12,9 @@ import gleam/result
 import gleam/string
 import glint
 import simplifile
+import envoy
+
+const aoc_cookie_name = "AOC_COOKIE"
 
 type Context {
   Context(year: Int, day: Day, add_parse: Bool, create_example_file: Bool, fetch_input: Bool)
@@ -61,7 +63,7 @@ type Err {
 
 fn err_to_string(e: Err) -> String {
   case e {
-    CookieNotDefined -> "'AOC_COOKIE' environment variable not defined"
+    CookieNotDefined -> "'" <> aoc_cookie_name <> "' environment variable not defined"
     FailedToCreateDir(d) -> "failed to create dir: " <> d
     FailedToCreateFile(f) -> "failed to create file: " <> f
     FailedToWriteToFile(e) -> "failed to write to file:" <> string.inspect(e)
@@ -106,7 +108,7 @@ fn handle_file_open_failure(
 }
 
 fn get_cookie_value() -> Result(String, Err) {
-  case os.get_env("AOC_COOKIE") {
+  case envoy.get(aoc_cookie_name) {
     Ok(cookie) -> Ok(cookie)
     _ -> Error(CookieNotDefined)
   }
@@ -231,7 +233,7 @@ pub fn new_command() {
     |> glint.flag_default(False)
     |> glint.flag_help("Fetch your own input from the AoC website.
 
-    Needs to have your AoC cookie stored in the 'AOC_COOKIE' environment variable"),
+    Needs to have your AoC cookie stored in the '" <> aoc_cookie_name <> "' environment variable"),
   )
   use _, args, flags <- glint.command()
   use days <- result.map(parse.days(args))

--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -56,16 +56,13 @@ fn create_input_file(
     let input_path = input.get_file_path(ctx.year, ctx.day, kind)
     case kind {
       input.Puzzle if ctx.fetch_input -> {
-        case
-          simplifile.is_file(input_path),
-          simplifile.is_directory(input_path)
-        {
-          Ok(False), Ok(False) -> {
+        case simplifile.file_info(input_path) {
+          Error(_) -> {
             use content <- result.try(download_input(ctx))
             simplifile.write(input_path, content)
             |> result.map_error(FailedToWriteToFile(_))
           }
-          _, _ -> Error(FileAlreadyExists(input_path))
+          _ -> Error(FileAlreadyExists(input_path))
         }
       }
       _ -> {


### PR DESCRIPTION
### Some context
I know you had a couple reason to not have implemented this, but that's a feature that I'd really use. So, as I've developed something, I guessed I could try to open a PR, in case you'd be interested to merge it.

Bear with me that those are the first ever lines of code I've written in Gleam, so that's probably not very idiomatic. That's one of the reason why I'm eager to get feedback (if you are interested in the feature).

### Description
The PR adds a new `--fetch` flag to the `new` command which will fetch the input directly from the AoC website (and put it at the correct place).
It just needs to have the session cookie of the user in the `AOC_COOKIE` environment variable.