### PR TITLE
Pad filenames with zeros by default

### DIFF
--- a/src/gladvent/internal/cmd/new.gleam
+++ b/src/gladvent/internal/cmd/new.gleam
@@ -1,7 +1,7 @@
 import filepath
 import gladvent/internal/cmd
 import gladvent/internal/input
-import gladvent/internal/parse.{type Day}
+import gladvent/internal/parse.{type Day, pad}
 import gladvent/internal/util
 import gleam/int
 import gleam/list
@@ -62,7 +62,7 @@ fn err_to_string(e: Err) -> String {
 }
 
 fn gleam_src_path(year: Int, day: Day) -> String {
-  filepath.join(cmd.src_dir(year), "day_" <> int.to_string(day) <> ".gleam")
+  filepath.join(cmd.src_dir(year), "day_" <> pad(day) <> ".gleam")
 }
 
 fn create_dir(dir: String) -> fn() -> Result(String, Err) {

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -67,6 +67,15 @@ fn string_trim(s: String, dir: Direction, sub: String) -> String {
   do_trim(s, dir, charlist.from_string(sub))
 }
 
+fn handle_file_path(year: Int, day: Day, input_kind: input.Kind) -> String {
+  let new = input.get_file_path(year, day, input_kind)
+  let old = input.get_legacy_file_path(year, day, input_kind)
+  case simplifile.is_file(new), simplifile.is_file(old) {
+    Ok(False), Ok(True) -> old
+    _, _ -> new
+  }
+}
+
 @external(erlang, "string", "trim")
 fn do_trim(a: String, b: Direction, c: Charlist) -> String
 
@@ -82,7 +91,7 @@ fn do(
     |> result.map_error(FailedToGetRunner),
   )
 
-  let input_path = input.get_file_path(year, day, input_kind)
+  let input_path = handle_file_path(year, day, input_kind)
   use input <- result.try(
     input_path
     |> simplifile.read()

--- a/src/gladvent/internal/input.gleam
+++ b/src/gladvent/internal/input.gleam
@@ -1,5 +1,6 @@
 import filepath
 import gladvent/internal/cmd
+import gladvent/internal/parse.{type Day, pad}
 import gleam/int
 
 pub type Kind {
@@ -7,7 +8,11 @@ pub type Kind {
   Puzzle
 }
 
-pub fn get_file_path(year: Int, day: Int, input_kind: Kind) -> String {
+pub fn get_file_path(year: Int, day: Day, input_kind: Kind) -> String {
+  filepath.join(dir(year), pad(day)) <> get_extension(input_kind)
+}
+
+pub fn get_legacy_file_path(year: Int, day: Day, input_kind: Kind) -> String {
   filepath.join(dir(year), int.to_string(day)) <> get_extension(input_kind)
 }
 

--- a/src/gladvent/internal/input.gleam
+++ b/src/gladvent/internal/input.gleam
@@ -8,11 +8,7 @@ pub type Kind {
 }
 
 pub fn get_file_path(year: Int, day: Int, input_kind: Kind) -> String {
-  filepath.join(dir(year), int.to_string(day))
-  <> case input_kind {
-    Example -> ".example.txt"
-    Puzzle -> ".txt"
-  }
+  filepath.join(dir(year), int.to_string(day)) <> get_extension(input_kind)
 }
 
 pub fn root() {
@@ -21,4 +17,11 @@ pub fn root() {
 
 pub fn dir(year) {
   filepath.join(root(), int.to_string(year))
+}
+
+fn get_extension(input_kind: Kind) -> String {
+  case input_kind {
+    Example -> ".example.txt"
+    Puzzle -> ".txt"
+  }
 }

--- a/src/gladvent/internal/parse.gleam
+++ b/src/gladvent/internal/parse.gleam
@@ -1,6 +1,7 @@
 import gleam/int
 import gleam/list
 import gleam/result
+import gleam/string
 import snag.{type Result}
 
 pub type Day =
@@ -27,4 +28,8 @@ pub fn day(s: String) -> Result(Day) {
 pub fn days(l: List(String)) -> Result(List(Day)) {
   list.try_map(l, day)
   |> snag.context("could not map day values to integers")
+}
+
+pub fn pad(day: Day) -> String {
+  int.to_string(day) |> string.pad_start(to: 2, with: "0")
 }

--- a/src/gladvent/internal/runners.gleam
+++ b/src/gladvent/internal/runners.gleam
@@ -1,6 +1,6 @@
 import filepath
 import gladvent/internal/cmd
-import gladvent/internal/parse.{type Day}
+import gladvent/internal/parse.{type Day, pad}
 import gladvent/internal/util.{defer}
 import gleam
 import gleam/bool
@@ -184,6 +184,15 @@ fn snagify_error(
   |> result.map_error(m)
 }
 
+fn handle_module_name(year: Int, day: Day, exists: fn(String) -> Bool) -> String {
+  let new = "aoc_" <> int.to_string(year) <> "/day_" <> pad(day)
+  let old = "aoc_" <> int.to_string(year) <> "/day_" <> int.to_string(day)
+  case exists(new), exists(old) {
+    False, True -> old
+    _, _ -> new
+  }
+}
+
 pub fn get_day(
   package: package_interface.Package,
   year: Int,
@@ -191,7 +200,7 @@ pub fn get_day(
 ) -> Result(DayRunner) {
   use <- snagify_error(with: runner_retrieval_error_to_snag)
   let module_name =
-    "aoc_" <> int.to_string(year) <> "/day_" <> int.to_string(day)
+    handle_module_name(year, day, dict.has_key(package.modules, _))
 
   // get the module for the specified year + day
   use module <- result.try(

--- a/test/parse_test.gleam
+++ b/test/parse_test.gleam
@@ -1,4 +1,4 @@
-import gladvent/internal/parse.{day}
+import gladvent/internal/parse.{day, pad}
 import gleam/int
 import gleam/list
 import gleeunit/should
@@ -18,4 +18,12 @@ pub fn day_error_test() {
     |> day
     |> should.be_error
   })
+}
+
+pub fn pad_test() {
+  pad(1) |> should.equal("01")
+}
+
+pub fn padded_day_to_int_test() {
+  "01" |> int.parse() |> should.be_ok() |> should.equal(1)
 }


### PR DESCRIPTION
This change sets the default behavior for newly created solutions to have padding by default (#18).

```
input/2024/1.txt -> input/2024/01.txt
src/aoc_2024/day_1.gleam -> src/aoc_2024/day_01.gleam
```
To not break existing solutions, filenames without padding will be handled and processed as before.

### Sanity check that legacy filenames still work

![image](https://github.com/user-attachments/assets/1ff5a176-15e3-4144-8197-9a289a59a60f)

### Create new day solution

![image](https://github.com/user-attachments/assets/92ccfed4-c435-420e-8bd0-53e5c49c406d)