### PR TITLE
Measure solution execution time with `--timed` flag

### DIFF
--- a/src/gladvent.gleam
+++ b/src/gladvent.gleam
@@ -27,6 +27,7 @@ pub fn run() {
     |> glint.add(at: ["new"], do: new.new_command())
     |> glint.group_flag(at: ["run"], of: run.timeout_flag())
     |> glint.group_flag(at: ["run"], of: run.allow_crash_flag())
+    |> glint.group_flag(at: ["run"], of: run.timed_flag())
     |> glint.add(at: ["run"], do: run.run_command())
     |> glint.add(at: ["run", "all"], do: run.run_all_command())
 

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -11,7 +11,6 @@ import gleam/dynamic.{type Dynamic}
 import gleam/erlang
 import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
-import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option}
@@ -282,9 +281,7 @@ fn format_execution_time(execution_time: Int) -> String {
     t if t > 1000 -> #(1000.0, 3, " ms")
     _ -> #(1.0, 0, " µs")
   }
-  let assert Ok(exec_time) =
-    int.to_float(execution_time) |> float.divide(divisor)
-  util.format_float(exec_time, precision) <> unit
+  util.format_float(int.to_float(execution_time) /. divisor, precision) <> unit
 }
 
 import gleam/pair

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -11,6 +11,7 @@ import gleam/dynamic.{type Dynamic}
 import gleam/erlang
 import gleam/erlang/atom
 import gleam/erlang/charlist.{type Charlist}
+import gleam/float
 import gleam/int
 import gleam/list
 import gleam/option.{type Option}
@@ -270,9 +271,20 @@ fn solve_res_to_string(
 
 fn exec_time_suffix(solution: Solution, timed: Bool) -> String {
   case timed {
-    True -> " (in " <> int.to_string(solution.execution_time) <> " µs)"
+    True -> " (in " <> format_execution_time(solution.execution_time) <> ")"
     False -> ""
   }
+}
+
+fn format_execution_time(execution_time: Int) -> String {
+  let #(divisor, precision, unit) = case execution_time {
+    t if t > 1_000_000 -> #(1_000_000.0, 3, " s")
+    t if t > 1000 -> #(1000.0, 3, " ms")
+    _ -> #(1.0, 0, " µs")
+  }
+  let assert Ok(exec_time) =
+    int.to_float(execution_time) |> float.divide(divisor)
+  util.format_float(exec_time, precision) <> unit
 }
 
 import gleam/pair

--- a/src/gladvent/internal/cmd/run.gleam
+++ b/src/gladvent/internal/cmd/run.gleam
@@ -47,7 +47,7 @@ type SolveResult =
 
 type Solution {
   Solution(value: Dynamic)
-  TimedSolution(value: Dynamic, time: Int)
+  TimedSolution(value: Dynamic, execution_time: Int)
 }
 
 fn run_err_to_snag(err: RunErr) -> Snag {
@@ -126,8 +126,8 @@ fn do(
 fn solve(solver: fn(a) -> Dynamic, input: a, timed: Bool) -> Solution {
   case timed {
     True -> {
-      let #(time, res) = util.timed(fn() { solver(input) })
-      TimedSolution(res, time)
+      let #(execution_time, res) = util.timed(fn() { solver(input) })
+      TimedSolution(res, execution_time)
     }
     False -> Solution(solver(input))
   }
@@ -272,7 +272,8 @@ fn solve_res_to_string(
 
 fn exec_time_suffix(solution: Solution) -> String {
   case solution {
-    TimedSolution(_, time) -> " (in " <> int.to_string(time) <> " µs)"
+    TimedSolution(_, execution_time) ->
+      " (in " <> int.to_string(execution_time) <> " µs)"
     _ -> ""
   }
 }

--- a/src/gladvent/internal/util.gleam
+++ b/src/gladvent/internal/util.gleam
@@ -1,3 +1,5 @@
+import gleam/erlang/charlist.{type Charlist}
+import gleam/float
 import gleam/int
 import gleam/list
 import gleam/set
@@ -14,3 +16,15 @@ pub fn deduplicate_sort(l: List(Int)) -> List(Int) {
 
 @external(erlang, "timer", "tc")
 pub fn timed(fun: fn() -> a) -> #(Int, a)
+
+pub fn format_float(input: Float, precision: Int) -> String {
+  case precision {
+    p if p >= 1 ->
+      do_format("~." <> int.to_string(precision) <> "f", input)
+      |> charlist.to_string
+    _ -> float.truncate(input) |> int.to_string
+  }
+}
+
+@external(erlang, "io_lib", "format")
+fn do_format(format: String, data: a) -> Charlist

--- a/src/gladvent/internal/util.gleam
+++ b/src/gladvent/internal/util.gleam
@@ -20,11 +20,11 @@ pub fn timed(fun: fn() -> a) -> #(Int, a)
 pub fn format_float(input: Float, precision: Int) -> String {
   case precision {
     p if p >= 1 ->
-      do_format("~." <> int.to_string(precision) <> "f", input)
+      do_format("~." <> int.to_string(precision) <> "f", [input])
       |> charlist.to_string
     _ -> float.truncate(input) |> int.to_string
   }
 }
 
 @external(erlang, "io_lib", "format")
-fn do_format(format: String, data: a) -> Charlist
+fn do_format(format: String, data: List(a)) -> Charlist

--- a/src/gladvent/internal/util.gleam
+++ b/src/gladvent/internal/util.gleam
@@ -11,3 +11,6 @@ pub fn defer(do later: fn() -> _, after now: fn() -> a) -> a {
 pub fn deduplicate_sort(l: List(Int)) -> List(Int) {
   l |> set.from_list |> set.to_list |> list.sort(int.compare)
 }
+
+@external(erlang, "timer", "tc")
+pub fn timed(fun: fn() -> a) -> #(Int, a)

--- a/test/util_test.gleam
+++ b/test/util_test.gleam
@@ -1,0 +1,17 @@
+import gladvent/internal/util
+import gleam/list
+import gleeunit/should
+
+pub fn format_float_test() {
+  use #(float, precision, expected) <- list.each([
+    #(123.123, 4, "123.1230"),
+    #(123.123, 2, "123.12"),
+    #(123.123, 0, "123"),
+    #(123.123, -3, "123"),
+    #(-123.123, 2, "-123.12"),
+    #(0.0, 0, "0"),
+  ])
+
+  util.format_float(float, precision)
+  |> should.equal(expected)
+}


### PR DESCRIPTION
## Changes
Adding functionality to measure the execution time of the `pt_1` and `pt_2` functions' in microseconds.

Wrote this before seeing https://github.com/TanklesXL/gladvent/issues/21 was open for this so went with the `--timed` flag to conditionally append the `(in XXX µs)` suffix to the solution value or met expectation message, but happy both to remove it or rename the flag.

## Before / After
<details>
<summary>[SPOILER ALERT]</summary>

| Before | After |
|--------|------|
| <img width="437" alt="Screenshot 2024-12-05 at 23 49 51" src="https://github.com/user-attachments/assets/e154aa42-c78b-42ed-850e-b5dd7aacba59"> | <img width="536" alt="Screenshot 2024-12-05 at 23 50 11" src="https://github.com/user-attachments/assets/db167838-9c85-4678-9216-3c1a669c1bdf"> |

</details>

## Notes
This doesn't take into account the execution time of the `parse` function, which can oftentimes skew the results by quite a bit, depending on how much heavy lifting `parse` does compared to `pt_X`. Regardless, I think this is a good starting point.
